### PR TITLE
Cloning and some maybe useful functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 Cargo.lock
 .idea
 *.iml
+.vscode

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use std::io::{Read, Write, Result, Error, ErrorKind};
 
 /// An enum to represent the byte order of the ByteBuffer object
 #[derive(Debug, Clone, Copy)]
-pub enum Endian{
+pub enum Endian {
     BigEndian,
     LittleEndian,
 }
@@ -78,6 +78,7 @@ impl ByteBuffer {
         }
     }
 
+
     /// Return the buffer size
     pub fn len(&self) -> usize {
         self.data.len()
@@ -87,12 +88,25 @@ impl ByteBuffer {
         self.data.is_empty()
     }
 
-    /// Clear the buffer and reinitialize the reading and writing cursor
+    /// Clear the buffer and reinitialize the reading and writing cursors
     pub fn clear(&mut self) {
         self.data.clear();
+        self.reset_cursors();
+        self.reset_bits_cursors();
+    }
+
+    /// Reinitialize the reading and writing cursor
+    pub fn reset_cursors(&mut self){
         self.wpos = 0;
         self.rpos = 0;
     }
+    
+    /// Reinitialize the bit reading and bit writing cursor
+    pub fn reset_bits_cursors(&mut self){
+        self.rbit = 0;
+        self.wbit = 0;
+    }
+
 
     /// Change the buffer size to size.
     ///
@@ -576,7 +590,7 @@ impl ByteBuffer {
         }
     }
 
-    /// Write the given value as a sequence of n bits
+    /// Write the given 
     ///
     /// #Example
     ///
@@ -593,6 +607,8 @@ impl ByteBuffer {
             self.write_bit((value & 1) != 0);
         }
     }
+
+    
 }
 
 impl Read for ByteBuffer {
@@ -636,5 +652,19 @@ impl std::fmt::Debug for ByteBuffer {
 
         write!(f, "ByteBuffer {{ remaining_data: {:?}, total_data: {:?}, endian: {:?} }}",
                remaining_data, self.data, self.endian)
+    }
+}
+
+
+impl Clone for ByteBuffer {
+    fn clone(&self) -> Self {
+        Self { 
+            data: self.data.clone(), 
+            wpos: self.wpos.clone(), 
+            rpos: self.rpos.clone(), 
+            rbit: self.rbit.clone(), 
+            wbit: self.wbit.clone(), 
+            endian: self.endian.clone() 
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -590,7 +590,7 @@ impl ByteBuffer {
         }
     }
 
-    /// Write the given 
+    /// Write the given value as a sequence of n bits 
     ///
     /// #Example
     ///

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -264,7 +264,40 @@ fn test_write() {
 fn test_flush() {
     let mut buffer = ByteBuffer::new();
     buffer.flush().unwrap();
+
 }
+
+#[test]
+fn cloning_and_read(){
+    let mut buffer = ByteBuffer::new();
+    for i in 0..10u8 {
+        buffer.write_u8(i);
+    }
+
+
+    let mut clone = buffer.clone();
+    for i in 0..10u8 {
+        assert_eq!(i, clone.read_u8().unwrap());
+    }
+}
+
+#[test]
+fn cursors_reset(){
+    let mut buffer = ByteBuffer::new();
+    for i in 0..10u8 {
+        buffer.write_u8(i);
+        buffer.read_u8().unwrap();
+    }
+
+    buffer.reset_cursors();
+    
+    for i in 0..10u8 {
+        assert_eq!(i, buffer.read_u8().unwrap());
+    }
+}
+
+
+
 
 #[test]
 fn test_debug() {


### PR DESCRIPTION
Hi.
This is not the first time I use this library for personal purposes, and I still wondered why ByteBuffer is not implemented Clone.

Because in complex scenarios, e.g. multithreading or sharing between multiple channels/consumers/etc, sometimes it's useful to pass the whole buffer by cloning and some implementations strictly depend on Clone, I decided to implement Clone. 

I also added some simple tests and useful functions. 
