### PR TITLE
fixed issue 15 : one too many bit written when write_bits is called

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -688,8 +688,6 @@ impl ByteBuffer {
         if n > 0 {
             self.write_bit((value >> (n - 1)) & 1 != 0);
             self.write_bits(value, n - 1);
-        } else {
-            self.write_bit((value & 1) != 0);
         }
     }
 }

--- a/tests/buffer.rs
+++ b/tests/buffer.rs
@@ -433,3 +433,20 @@ overread_tests! {
     overread_bit: ByteBuffer::new().read_bit(),
     overread_bits: ByteBuffer::new().read_bits(1),
 }
+
+#[test]
+fn test_issue_15_multiple_write_bits() {
+    let mut bytes = ByteBuffer::new();
+    bytes.write_bits(0x7, 3);
+    bytes.write_bits(7, 4);
+
+    assert_eq!(bytes.to_hex_dump(), "0xee");
+
+    let mut bytes = ByteBuffer::new();
+    bytes.write_u8(0x2);
+    bytes.write_u16(0);
+    bytes.write_bits(0x4, 3);
+    bytes.write_bits(7, 5);
+
+    assert_eq!(bytes.to_hex_dump(), "0x02 0x00 0x00 0x87");
+}


### PR DESCRIPTION
When using write_bits, one more bit was written, resulting in a wrong result when using write_bits multiple times or for writing any multiple of 8 bits